### PR TITLE
changing missing variable in setup to not trigger error

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ def check_dependencies():
             missing_deps.append(dep)
 
     if missing_deps:
-        raise ImportError("Missing dependencies: %s" % missing)
+        raise ImportError("Missing dependencies: %s" % missing_deps)
 
 if __name__ == "__main__":
 


### PR DESCRIPTION
This just changes "missing" to "missing_deps" so it doesn't trigger an error,.