### PR TITLE
remove singleton dim when creating outdata

### DIFF
--- a/pydeface/__main__.py
+++ b/pydeface/__main__.py
@@ -116,7 +116,7 @@ def main():
     # multiply mask by infile and save
     infile_img = load(infile)
     tmpfile_img = load(tmpfile)
-    outdata = infile_img.get_data() * tmpfile_img.get_data()
+    outdata = infile_img.get_data().squeeze() * tmpfile_img.get_data()
     outfile_img = Nifti1Image(outdata, infile_img.get_affine(),
                               infile_img.get_header())
     outfile_img.to_filename(outfile)


### PR DESCRIPTION
I encountered an issue where the nifti files had an additional singleton dimension. Using squeeze fixed the problem. It might be of general use. I do not know how the nifti files were created, which isn't very helpful. This pull request might be helpful for others encountering the same issue. I don't know the codebase well enough to know whether it might cause problems itself though.