### PR TITLE
Make pydeface work with multivolume anatomicals

### DIFF
--- a/pydeface/__main__.py
+++ b/pydeface/__main__.py
@@ -25,6 +25,7 @@
 import argparse
 import os
 import tempfile
+import numpy as np
 from nipype.interfaces import fsl
 from nibabel import load, Nifti1Image
 from pkg_resources import require

--- a/pydeface/__main__.py
+++ b/pydeface/__main__.py
@@ -116,7 +116,12 @@ def main():
     # multiply mask by infile and save
     infile_img = load(infile)
     tmpfile_img = load(tmpfile)
-    outdata = infile_img.get_data().squeeze() * tmpfile_img.get_data()
+    try:
+        outdata = infile_img.get_data().squeeze() * tmpfile_img.get_data()
+    except ValueError:
+        tmpdata = np.array([tmpfile_img.get_data()]*infile_img.get_data().shape[-1])
+        outdata = infile_img.get_data() * tmpdata
+    
     outfile_img = Nifti1Image(outdata, infile_img.get_affine(),
                               infile_img.get_header())
     outfile_img.to_filename(outfile)

--- a/pydeface/__main__.py
+++ b/pydeface/__main__.py
@@ -120,7 +120,7 @@ def main():
     try:
         outdata = infile_img.get_data().squeeze() * tmpfile_img.get_data()
     except ValueError:
-        tmpdata = np.array([tmpfile_img.get_data()]*infile_img.get_data().shape[-1])
+        tmpdata = np.stack([tmpfile_img.get_data()]*infile_img.get_data().shape[-1], axis=-1)
         outdata = infile_img.get_data() * tmpdata
     
     outfile_img = Nifti1Image(outdata, infile_img.get_affine(),


### PR DESCRIPTION
I'm preparing a study that's got some despot sequences in it for release. The despot sequences are multivolume anatomicals that I'd like to deface, so I added a try except on the multiplication of the mask and input image.