### PR TITLE
Latest setuptools v82.0.0 lacks pkg_resource

### DIFF
--- a/pydeface/__main__.py
+++ b/pydeface/__main__.py
@@ -3,7 +3,7 @@
 
 import argparse
 from nibabel import load, Nifti1Image
-from pkg_resources import require
+from importlib.metadata import version, PackageNotFoundError
 import pydeface.utils as pdu
 import sys
 import shutil
@@ -83,7 +83,12 @@ def main():
                         help='Do not catch exceptions and show exception '
                         'traceback (Drop into pdb debugger).')
 
-    welcome_str = 'pydeface ' + require("pydeface")[0].version
+    pkg_name = __spec__.parent
+    try:
+        pkg_version = version(pkg_name)
+    except PackageNotFoundError:
+        pkg_version = 'unknown'
+    welcome_str = f'{pkg_name} {pkg_version}'
     welcome_decor = '-' * len(welcome_str)
     print(welcome_decor + '\n' + welcome_str + '\n' + welcome_decor)
 

--- a/pydeface/utils.py
+++ b/pydeface/utils.py
@@ -3,7 +3,7 @@
 import os
 import shutil
 import sys
-from pkg_resources import resource_filename, Requirement
+from importlib.resources import files
 import tempfile
 import numpy as np
 from nipype.interfaces import fsl
@@ -13,11 +13,9 @@ from nibabel import load, Nifti1Image
 def initial_checks(template=None, facemask=None):
     """Initial sanity checks."""
     if template is None:
-        template = resource_filename(Requirement.parse("pydeface"),
-                                     "pydeface/data/mean_reg2mean.nii.gz")
+        template = files("pydeface").joinpath("data/mean_reg2mean.nii.gz")
     if facemask is None:
-        facemask = resource_filename(Requirement.parse("pydeface"),
-                                     "pydeface/data/facemask.nii.gz")
+        facemask = files("pydeface").joinpath("data/facemask.nii.gz")
 
     if not os.path.exists(template):
         raise Exception('Missing template: %s' % template)

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,6 @@ setup(name='pydeface',
           'numpy',
           'nibabel',
           'nipype',
-          'setuptools',  # needed at runtime (for the pkg_resources module)
       ],
       entry_points={
             'console_scripts': [


### PR DESCRIPTION
Use [`importlib`](https://docs.python.org/3/library/importlib.html) instead. That's its exact purpose, and it's available in Python 3.7.

Follow-up of #42 / be457d64498b8a09d605e6a4a41f655db2e249d3.