### PR TITLE
Check for FLIRT instead of the FSL launcher

### DIFF
--- a/pydeface/utils.py
+++ b/pydeface/utils.py
@@ -90,8 +90,8 @@ def deface_image(
 ):
     if not infile:
         raise ValueError('infile must be specified')
-    if shutil.which('fsl') is None:
-        raise OSError('fsl cannot be found on the path')
+    if shutil.which('flirt') is None:
+        raise OSError('FSL flirt cannot be found on the path')
 
     template, facemask = initial_checks(template, facemask)
     outfile = output_checks(infile, outfile, force)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -30,6 +30,28 @@ def test_get_outfile_type():
         pdu.get_outfile_type('path.suffix')
 
 
+def test_deface_image_requires_flirt(monkeypatch, tmp_path):
+    bin_dir = tmp_path / 'bin'
+    bin_dir.mkdir()
+    monkeypatch.setenv('PATH', str(bin_dir))
+
+    with pytest.raises(OSError, match='flirt'):
+        pdu.deface_image('input.nii.gz')
+
+
+def test_deface_image_accepts_flirt_without_fsl(monkeypatch, tmp_path):
+    bin_dir = tmp_path / 'bin'
+    bin_dir.mkdir()
+    flirt = bin_dir / 'flirt'
+    flirt.write_text('#!/bin/sh\nexit 0\n')
+    flirt.chmod(0o755)
+    monkeypatch.setenv('PATH', str(bin_dir))
+    monkeypatch.delenv('FSLDIR', raising=False)
+
+    with pytest.raises(Exception, match='FSLDIR'):
+        pdu.deface_image('input.nii.gz')
+
+
 def test_deface_image():
     if which('fsl'):
         # Piece together test data path


### PR DESCRIPTION
## Summary
- check for the `flirt` executable that pydeface actually invokes through Nipype
- report a FLIRT-specific error when it is unavailable
- add regression coverage for missing FLIRT and FLIRT-without-`fsl` PATH layouts

`master` is the currently published branch and still contains this regression, while the historical fix exists only on `devel`; this PR intentionally ports the narrow fix to `master`.

Closes #82.

## Validation
- `PYTHONPATH=. pytest -q tests/test_utils.py`
- `ruff check pydeface/utils.py tests/test_utils.py`
- `ruff format --check pydeface/utils.py tests/test_utils.py`
