### PR TITLE
Apply the defacing mask to every volume of a 4D image

### DIFF
--- a/pydeface/__main__.py
+++ b/pydeface/__main__.py
@@ -139,7 +139,9 @@ def main():
             try:
                 outdata = applyfile_data * warped_mask_data
             except ValueError:
-                tmpdata = np.stack(warped_mask_data * applyfile_data.shape[-1], axis=-1)
+                tmpdata = np.stack(
+                    [warped_mask_data] * applyfile_data.shape[-1], axis=-1
+                )
                 outdata = applyfile_data * tmpdata
             applyfile_img = Nifti1Image(
                 outdata, applyfile_img.affine, applyfile_img.header

--- a/pydeface/utils.py
+++ b/pydeface/utils.py
@@ -129,7 +129,7 @@ def deface_image(
     try:
         outdata = infile_data.squeeze() * warped_mask_data
     except ValueError:
-        tmpdata = np.stack(warped_mask_data * infile_img.shape[-1], axis=-1)
+        tmpdata = np.stack([warped_mask_data] * infile_img.shape[-1], axis=-1)
         outdata = infile_data * tmpdata
 
     masked_brain = Nifti1Image(outdata, infile_img.affine, infile_img.header)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,9 +3,36 @@ import tempfile
 from pathlib import Path
 from shutil import which
 
+import nibabel as nib
+import numpy as np
 import pytest
 
 import pydeface.utils as pdu
+
+
+def _make_flirt_stub(reference_shape3d):
+    """Build a FLIRT replacement writing a 3D mask, so FSL is not needed."""
+
+    class StubInputs:
+        pass
+
+    class StubFLIRT:
+        def __init__(self):
+            self.inputs = StubInputs()
+
+        def run(self):
+            out = getattr(self.inputs, 'out_file', None)
+            if out is not None:
+                data = np.ones(reference_shape3d, dtype=np.int16)
+                data[0, 0, 0] = 0
+                nib.Nifti1Image(data, np.eye(4)).to_filename(out)
+            mat = getattr(self.inputs, 'out_matrix_file', None)
+            if mat is not None:
+                with open(mat, 'w') as fh:
+                    fh.write('1 0 0 0\n0 1 0 0\n0 0 1 0\n0 0 0 1\n')
+            return self
+
+    return StubFLIRT
 
 
 def test_cleanup_files():
@@ -72,3 +99,38 @@ def test_deface_image():
 
     else:
         pytest.skip('No FSL to run defacing.')
+
+
+@pytest.mark.parametrize('shape3d', [(6, 7, 8), (3, 4, 5)])
+def test_deface_image_multivolume(tmp_path, monkeypatch, shape3d):
+    """The 3D mask must be applied to every volume of a 4D image.
+
+    Two geometries, because the failure differs. When the first axis and the
+    volume count differ, the mask cannot broadcast and defacing raises. When
+    they match, it broadcasts and writes wrong values instead.
+    """
+    nvolumes = 3
+    indata = np.arange(1, np.prod(shape3d) * nvolumes + 1, dtype=np.int16).reshape(
+        (*shape3d, nvolumes)
+    )
+    infile = tmp_path / 'sub-01_bold.nii.gz'
+    nib.Nifti1Image(indata, np.eye(4)).to_filename(infile)
+
+    monkeypatch.setenv('FSLDIR', str(tmp_path))
+    monkeypatch.setattr(pdu.shutil, 'which', lambda name: '/usr/bin/' + name)
+    monkeypatch.setattr(pdu.fsl, 'FLIRT', _make_flirt_stub(shape3d))
+
+    pdu.deface_image(infile=str(infile), forcecleanup=True)
+
+    outdata = np.asarray(
+        nib.load(tmp_path / 'sub-01_bold_defaced.nii.gz').dataobj
+    ).astype(np.int16)
+
+    # The mask zeroes a single voxel, which must be zeroed in every volume,
+    # while every other voxel keeps its original value in every volume.
+    expected = indata.copy()
+    expected[0, 0, 0, :] = 0
+    assert outdata.shape == indata.shape
+    assert (outdata[0, 0, 0, :] == 0).all()
+    assert (outdata[1, 1, 1, :] == indata[1, 1, 1, :]).all()
+    assert np.array_equal(outdata, expected)


### PR DESCRIPTION
`utils.py:132` builds the 4D mask with

```python
tmpdata = np.stack(warped_mask_data * infile_img.shape[-1], axis=-1)
```

`warped_mask_data * n` is a scalar multiplication, so it gives one 3D array full
of `n` rather than `n` copies of the mask. `np.stack` then iterates that array as
a sequence of 2D slices, so the result comes out 3D with the axes rolled, `(X, Y,
Z)` becoming `(Y, Z, X)`, holding `n` where the mask held 1.

The brackets went missing in 2c6e781 ("Fix nibabel `.get_data` warnings", July
2022), which rewrote `get_data()` to `dataobj`. `__main__.py:142` carries the
same expression and took the same change. `git tag --contains 2c6e781` gives
v2.0.1, v2.0.2 and v2.1.0; of those, PyPI carries 2.0.2 and 2.1.0, so every
release installable from PyPI since 2.0.2 ships the broken form, including the
current 2.1.0.

The `except` branch is from #17 ("Make pydeface work with multivolume
anatomicals", 2018), which had an axis problem of its own: its first commit wrote
`np.array([mask] * n)`, volumes on the leading axis, and its last commit d2668e33
("fix axes ordering") changed that to `np.stack([mask] * n, axis=-1)` to put them
last. Measured with a `(6, 7, 8)` mask and 3 volumes:

```python
np.array([mask] * 3)           # (3, 6, 7, 8)  PR #17 before d2668e33
np.stack([mask] * 3, axis=-1)  # (6, 7, 8, 3)  d2668e33, correct
np.stack(mask * 3, axis=-1)    # (7, 8, 6)     after 2c6e781, every value 3
```

So 2c6e781 didn't reintroduce the old leading-axis mistake. It produced a third
shape matching neither, one rank down, and the branch stopped working at all.

On current `master`, defacing a 4D image, with FLIRT stubbed so no FSL is needed:

```
Traceback (most recent call last):
  File "pydeface/utils.py", line 130, in deface_image
    outdata = infile_data.squeeze() * warped_mask_data
              ~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~
ValueError: operands could not be broadcast together with shapes (6,7,8,3) (6,7,8)

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "pydeface/utils.py", line 133, in deface_image
    outdata = infile_data * tmpdata
              ~~~~~~~~~~~~^~~~~~~~~
ValueError: operands could not be broadcast together with shapes (6,7,8,3) (7,8,6)
```

The second failure comes from inside the handler meant to catch the first.

Where the first axis happens to equal the volume count, the wrong array still
broadcasts and nothing is raised. On a `(3, 4, 5, 3)` input the voxel the mask
zeroes comes out `[0, 6, 9]` across the three volumes instead of `[0, 0, 0]`, its
input value having been `[1, 2, 3]`, and a voxel the mask keeps goes from `[79,
80, 81]` to `[237, 240, 243]`. Everything that survives is multiplied by the
volume count.

Restoring the list repetition fixes both. I kept this to putting back what
2c6e781 dropped rather than rewriting the branch. `warped_mask_data[...,
np.newaxis]` gives a bit-identical result without materialising the copies and is
the better expression, but that is a change to the branch rather than a repair of
it, so I left it alone.

The regression test is parametrized over both geometries and checks that the
masked voxel is zero in every volume while every other voxel keeps its original
value. It stubs FLIRT rather than gating on FSL, for two reasons. The assertions
need a mask with known contents, and real FLIRT registration on a tiny synthetic
image wouldn't give one. And a test gated the way `test_deface_image` is gated
would run in exactly one place: the Actions matrix installs no FSL, so it would
skip in all six cells there, and only the CircleCI docker image, whose pixi dev
environment carries `fsl-flirt` and the `fsl` launcher from `fsl-misc_tcl`, would
exercise it. The stub runs everywhere, CircleCI included.

```
python -m pytest tests/ -q

  24919aa with the new test only    2 failed, 3 passed, 1 skipped
  with this change                  5 passed, 1 skipped
```

The remaining skip is `test_deface_image`. `ruff check .` and
`ruff format --check .` are clean on 0.15.12.

Three things to flag. The `--applyto` line in `__main__.py` is the identical
expression broken by the same commit and is fixed here too, but the test drives
`deface_image` only; `__main__.py` has no coverage in the suite today, and
writing its first test seemed out of proportion to a two line fix. I ran this on
Linux with Python 3.12.3 and numpy 2.5.1, a single cell of the matrix. And I have
one other open item at this repo, #82, on the FSL presence check in
`deface_image`; this fix is independent of it, though the test's `shutil.which`
stub does sidestep the check that issue describes.
